### PR TITLE
Clean up Python 2 compatibility remnants

### DIFF
--- a/robot/__init__.py
+++ b/robot/__init__.py
@@ -3,9 +3,9 @@
 April tags a marker recognition system. Also performs convince functions for use
 by shepherd"""
 
-import importlib
+import importlib.util
 
-has_picamera = importlib.find_loader("picamera") is not None
+has_picamera = importlib.util.find_spec("picamera") is not None
 
 if not has_picamera:
     import sys
@@ -35,10 +35,10 @@ from robot.game_config import (
 )
 
 
-MINIUM_VERSION = (3, 6)
-if sys.version_info <= MINIUM_VERSION:
+MINIMUM_VERSION = (3, 6)
+if sys.version_info <= MINIMUM_VERSION:
     raise ImportError(
-        "Expected python {} but instead got {}".format(MINIUM_VERSION, sys.version_info)
+        "Expected python {} but instead got {}".format(MINIMUM_VERSION, sys.version_info)
     )
     
 __all__ = [

--- a/robot/apriltags3.py
+++ b/robot/apriltags3.py
@@ -1,17 +1,13 @@
-#!/usr/bin/env python
+#!/usr/bin/env python3
 """Python wrapper for C version of apriltags. This program creates two
 classes that are used to detect apriltags and extract information from
 them. Using this module, you can identify all apriltags visible in an
 image, and get information about the location and orientation of the
 tags.
 
-This module is both python 2 and 3 compatiable.
-
 Forked from: <https://github.com/duckietown/apriltags3-py>
 Added support for polar cords and variable sized markers
 """
-from __future__ import division
-from __future__ import print_function
 
 import ctypes
 import os

--- a/robot/calibrate_camera.py
+++ b/robot/calibrate_camera.py
@@ -26,46 +26,47 @@ def get_reading():
 def get_reading_number(error):
     result = int(K_READING_COUNTS / error)
     result = abs(result)
-    if result is 0:
+    if result == 0:
         result = 1
     elif result > 6:
         result = 6
     return result
 
 
-R = robot.Robot()
-result = {}
+if __name__ == "__main__":
+    R = robot.Robot()
+    result = {}
 
-for res in [(640, 480), (1280, 720), (1640, 1232), (1920, 1080)]:
-    print("Checking res {}".format(res))
-    R.camera.res = res
-    pprint.pprint(R.camera.focal_lengths)
+    for res in [(640, 480), (1280, 720), (1640, 1232), (1920, 1080)]:
+        print("Checking res {}".format(res))
+        R.camera.res = res
+        pprint.pprint(R.camera.focal_lengths)
 
-    error = THRESHOLD + 1.0
-    previous_error = error
-    while abs(error) > THRESHOLD:
-        value = R.camera.focal_lengths[res][0]
-        p = error * KP
-        d = (previous_error - error) * KD
-        value += p + d
-
-        R.camera.focal_lengths[res] = (value, value)
-        R.camera._update_camera_params(R.camera.focal_lengths)
-
-        reading_counts = get_reading_number(error)
-
-        dists = [get_reading() for _ in range(reading_counts)]
-        average_dist = (sum(dists))/reading_counts
-
+        error = THRESHOLD + 1.0
         previous_error = error
-        error = TARGET - average_dist
+        while abs(error) > THRESHOLD:
+            value = R.camera.focal_lengths[res][0]
+            p = error * KP
+            d = (previous_error - error) * KD
+            value += p + d
 
-        print("Tried: {} got dist {} error: {}".format(
-            value, average_dist, error))
-        print("    Max: {} min: {} range: {}".format(
-            max(dists), min(dists), max(dists) - min(dists)))
-        print("    P = {} reading_counts {}".format(error * KP, reading_counts))
+            R.camera.focal_lengths[res] = (value, value)
+            R.camera._update_camera_params(R.camera.focal_lengths)
 
-    result[res] = (value, value)
+            reading_counts = get_reading_number(error)
 
-pprint.pprint(result)
+            dists = [get_reading() for _ in range(reading_counts)]
+            average_dist = (sum(dists))/reading_counts
+
+            previous_error = error
+            error = TARGET - average_dist
+
+            print("Tried: {} got dist {} error: {}".format(
+                value, average_dist, error))
+            print("    Max: {} min: {} range: {}".format(
+                max(dists), min(dists), max(dists) - min(dists)))
+            print("    P = {} reading_counts {}".format(error * KP, reading_counts))
+
+        result[res] = (value, value)
+
+    pprint.pprint(result)

--- a/robot/game_config/startup_poems.py
+++ b/robot/game_config/startup_poems.py
@@ -62,7 +62,7 @@ class POEM_ON_STARTUP:
         as an argument because I don't have the energy to try importing it,
         I just spent quite a while struggling with the new brains.
         """
-        jokeNo = randint(0,len(POEM_ON_STARTUP.jokes))
+        jokeNo = randint(0, len(POEM_ON_STARTUP.jokes) - 1)
         jokeToPrint = "I don't know what went wrong, but we messed up our joke loading ;-;"
         try:
             jokeToPrint = POEM_ON_STARTUP.jokes[jokeNo]

--- a/robot/greengiant.py
+++ b/robot/greengiant.py
@@ -183,7 +183,7 @@ class GreenGiantInternal():
     def __init__(self, bus):
         self._bus = bus
         self._version = self.get_version()
-        print ("Version: ", self._version)
+        print("Version:", self._version)
         self.enabled_12v = False
         self.set_motor_power(self.enabled_12v)
 

--- a/robot/greengiant.py
+++ b/robot/greengiant.py
@@ -43,39 +43,11 @@ _GG_GPIO_MASKS = {
 
 
 
-#__GG_MOTOR_ERROR_STATE_MASK = {
-#    "GG_Motor_A_Open_Load":     1 << 0        # not always an error, may be weedy motors
-#    "GG_Motor_A_Short":         1 << 1            # dead short or motor too power hungry for driver
-#    "GG_Motor_A_Overheat":      1 << 2         # In excess of 165 Degrees at Junction - beware of the hot case
-#    "GG_Motor_A_Short_To_Rail": 1 << 3   # connection detected between GND and motor or 12v and motor
-#    "GG_Motor_B_Open_Load":     1 << 4
-#    "GG_Motor_B_Short":         1 << 5
-#    "GG_Motor_B_Overheat":      1 << 6
-#    "GG_Motor_B_Short_To_Rail": 1 << 7
-#}
-
-#__GG_SYSTEM_ERROR_STATE_MASK = {
-#
-#    GG_System_5v_Fault: 1 << 0          # Short on GPIO or Servo overload
-#    GG_System_MotorPower_Fault: 1 << 1  # Probably should not happen, but may with two high power motors
-#    GG_System_12v_Fault: 1 << 2         # Short or overload on 12v Acc port
-#    # avr overheat ?
-#    # low power lockout ?
-#}
-
-
 
 _GG_I2C_ADDR = 0x08
 
 _GG_SERVO_PWM_BASE = 1
 _GG_GPIO_PWM_BASE = 48
-
-# PWM (external ports numbered from zero on PiLow)
-#        H  L
-# PWM 1: 0, 1
-# PWM 2: 2, 3
-# PWM 3: 4, 5
-# PWM 4: 6, 7
 
 _GG_GG_PWM_CENTER = 374
 _GG_GG_PWM_PERCENT_HALF_RANGE = 125
@@ -385,18 +357,7 @@ class GreenGiantGPIOPin():
         else:
             raise IOError(f"Attempt set PWM value on GPIO only pin")
 
-    #def __bool__(self):
-    #    """Return a bool if in a digital mode or a float if in an analogue"""
-    #    if self._gpio_base is not None:
-    #        if self._mode in self._digital_read_modes:
-    #            return self.digital
-    #
-    #        raise ValueError(f"Tried to evaluate GPIO {self._index} as a True/False "
-    #                         f"but current mode:{self._mode} is not in {self._digital_read_modes}")
-    #    else:
-    #        raise IOError(f"Attempt use value of a PWM only pin")
-
-    def __setitem__(self, value):
+    def set_value(self, value):
         if self._mode is PWM_SERVO:
             self.pwm = value
         elif self._mode is OUTPUT:
@@ -404,7 +365,7 @@ class GreenGiantGPIOPin():
         else:
             raise IOError(f"Attempt to write to a pin configured for input")
 
-    def __getitem__(self):
+    def get_value(self):
         if self._mode is PWM_SERVO:
             return self.pwm
         elif self._mode is TIMER:
@@ -471,55 +432,7 @@ class GreenGiantGPIOPinList():
     def off(self):
         for pin in self._list:
             pin.mode = INPUT
-"""
-class GreenGiantPWM():
-    ""An object implementing a descriptor protocol to control the servos for Green Giant only
-    PWM is combined into GPIO for the PiLow
-    ""
 
-    def __init__(self, bus, version):
-        self._bus = bus
-        self._version = version
-    def __getitem__(self, index):
-        if self._version < 10:
-            index = _decrement_pin_index(index)
-
-        command = _GG_PWM_START + (index * 2)
-        # TODO - Use a function for this?
-        high = self._bus.read_byte_data(_GG_I2C_ADDR, command)
-        low = self._bus.read_byte_data(_GG_I2C_ADDR, command + 1)
-        value = low + (high << 8)
-
-        if self._version < 10:
-            return (value - _GG_GG_PWM_CENTER) * 100 / _GG_GG_PWM_PERCENT_HALF_RANGE
-        else:
-            return (value - _GG_PiLow_PWM_CENTER) * 100 / _GG_PiLow_PWM_PERCENT_HALF_RANGE
-
-    def __setitem__(self, index, percent):
-        if self._version < 10:
-            index = _decrement_pin_index(index)
-        command = _GG_PWM_START + (index * 2)
-        if self._version < 10:
-            value = _GG_GG_PWM_CENTER + (percent / 100 * _GG_GG_PWM_PERCENT_HALF_RANGE)
-            value = clamp(value, _GG_GG_PWM_MIN, _GG_GG_PWM_MAX)
-        else:
-            value = _GG_PiLow_PWM_CENTER + (percent / 100 * _GG_PiLow_PWM_PERCENT_HALF_RANGE)
-            value = clamp(value, _GG_PiLow_PWM_MIN, _GG_PiLow_PWM_MAX)
-        value = int(value)
-
-        low = value & 0xFF
-        high = value >> 8
-
-        self._bus.write_byte_data(_GG_I2C_ADDR, command, high)
-        self._bus.write_byte_data(_GG_I2C_ADDR, command + 1, low)
-
-    def off(self):
-        for i in range(4):
-            if self._version < 10:
-                self.__setitem__(i + 1, 0)
-            else:
-                self.__setitem__(i, 0)
-"""
 _SYSTEM_VOLTAGE = 12
 _MAX_MOTOR_PWM_VALUE = 0xff
 
@@ -552,7 +465,7 @@ class GreenGiantMotors():
         if index not in (0,1):
             raise IndexError(
                 f"motor index must be in (0,1) but instead got {index}")
-        hex_mag = self._bus.read_byte_data(_GG_I2C_ADDR, _GG_MOTOR_A_MAG + index)
+        hex_mag = self._bus.read_byte_data(_GG_I2C_ADDR, _GG_MOTOR_MAG_START + index)
 
         return hex_mag * (100.0 / 256.0) * self.power_scaling_factor
 

--- a/robot/log.py
+++ b/robot/log.py
@@ -1,15 +1,5 @@
-# pylint: skip-file
-# TODO is this dead code?
+"""Logging configuration for the robot package."""
 import logging
 
-# Python 2.6's logging doesn't have NullHandler
-
-
-class NullHandler(logging.Handler):
-    def emit(self, record):
-        pass
-
-
-# Default to sending our log messages nowhere
-logger = logging.getLogger("sr")
-logger.addHandler(NullHandler())
+logger = logging.getLogger("robot")
+logger.addHandler(logging.NullHandler())

--- a/robot/reset.py
+++ b/robot/reset.py
@@ -23,8 +23,8 @@ def reset():
 
     if version < 10:
         c.CytronBoard(1).stop()
-        gg.GreenGiantGPIOPinList(self.bus, version, 5, None, gg._GG_SERVO_PWM_BASE)
-        gg.GreenGiantGPIOPinList(self.bus, version, 5, gg._GG_GPIO_GPIO_BASE, None)
+        gg.GreenGiantGPIOPinList(bus, version, 5, None, gg._GG_SERVO_PWM_BASE)
+        gg.GreenGiantGPIOPinList(bus, version, 5, gg._GG_GPIO_GPIO_BASE, None)
     else:
         gg.GreenGiantMotors(bus, 1).stop()
         gg.GreenGiantGPIOPinList(bus, version, 5, gg._GG_SERVO_GPIO_BASE, gg._GG_SERVO_PWM_BASE).off()

--- a/robot/vision.py
+++ b/robot/vision.py
@@ -310,8 +310,8 @@ class RoboConPiCamera(Camera):
                 cam_res = PI_2_1_CAMERA_RES_MAP[new_res]
                 self._pi_camera.resolution = cam_res
             else:
-                self._pi_camera.create_still_configuration(main={"size": new_res})
-                self._pi_camera.configure(self._camera_config)
+                cfg = self._pi_camera.create_still_configuration(main={"size": new_res})
+                self._pi_camera.configure(cfg)
             self._resultant_resolution = new_res
             self._update_camera_params(self.focal_lengths)
             if thread_running:

--- a/robot/vision.py
+++ b/robot/vision.py
@@ -252,7 +252,7 @@ class RoboConPiCamera(Camera):
             elif start_res not in self.focal_lengths:
                 raise "Invalid resolution for camera."
         else:
-           print ("unknown camera: " + self._pi_camera.camera_properties)
+           print("unknown camera:", self._pi_camera.camera_properties)
         
         self._pi_camera.set_logging(picamera2.Picamera2.ERROR)
         self._resultant_resolution = None

--- a/robot/wrapper.py
+++ b/robot/wrapper.py
@@ -201,17 +201,7 @@ class Robot():
 
     @property
     def enable_motors(self):
-        """Return if motors are currently enabled
-
-        For the GG board this will be the state of the 12v line, which we cannot query,
-        so return what it was set to.
-
-        For the PiLow series the Motors have both a power control and a enable. Generally
-        the Power should not be switched on and off, just the enable bits. The power may
-        be tripped in extreme circumstances. I guess that here we want to report any
-        reason for  the motors not working, which includes power and enable
-
-        """
+        """Return if motors are currently enabled"""
         if self._gg_version < 10:
             return self._green_giant.enable_12v
         else:
@@ -219,33 +209,9 @@ class Robot():
 
     @enable_motors.setter
     def enable_motors(self, on):
-        """An nice alias for set_12v"""
-        if self._version < 10:
-            return self._green_giant.enable_motors(on)
-
-    @property
-    def enable_motors(self):
-        """Return if motors are currently enabled
-
-        For the GG board this will be the state of the 12v line, which we cannot query,
-        so return what it was set to.
-
-        For the PiLow series the Motors have both a power control and a enable. Generally
-        the Power should not be switched on and off, just the enable bits. The power may
-        be tripped in extreame circumstances. I guess that here we want to report any 
-        reason for  the motors not working, which includes power and enable
-
-        """
+        """Enable or disable motors"""
         if self._gg_version < 10:
-            return self._green_giant.enable_12v
-        else:
-            return self._green_giant.get_motorpwr() and self._green_giant.get_enable()
-
-    @enable_motors.setter
-    def enable_motors(self, on):
-        """An nice alias for set_12v"""
-        if self._version < 10:
-            return self._green_giant.enable_motors(on)
+            self._green_giant.enable_motors(on)
 
     @property
     def enable_12v(self):


### PR DESCRIPTION
Remove from __future__ imports from apriltags3.py (Python 3 only). Fix print statements with unnecessary spaces to Python 3 style. Update shebang to python3.